### PR TITLE
Fixed bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:16-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm i
 
 # Rebuild source code only when needed
 FROM node:16 AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:16-alpine AS deps
 
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY package.json package-lock.json ./
+COPY package*.json ./
 RUN npm ci
 
 # Rebuild source code only when needed


### PR DESCRIPTION
Well since you don't have any package-lock.json in the repo, the install requirements part was completely crashing.. So I updated the dockerfile to take in consideration that there might not be a package-lock.json