### PR TITLE
Fix Bug where {your} is not replaced

### DIFF
--- a/components/Data.tsx
+++ b/components/Data.tsx
@@ -11518,7 +11518,11 @@ export default function Data({ data, demo }: any): ReactElement {
                                   .replace(
                                     /{you've}/g,
                                     data?.dataFile ? "They've" : "You've"
-                                  ),
+                                  )
+                                  .replace(
+                                    /{your}/g,
+                                    data?.dataFile ? "Their" : "Your"
+                                  )
                               }}
                             />
                           </div>


### PR DESCRIPTION
Fix a bug where {your} is not replaced in event descriptions.

![image](https://user-images.githubusercontent.com/30734036/200886162-14d6ad46-36d1-4a77-9e8f-16c83f04149e.png)
