### PR TITLE
🐛 fix yearly message graph being backward

### DIFF
--- a/components/Upload.tsx
+++ b/components/Upload.tsx
@@ -2198,7 +2198,7 @@ export default function Upload(): ReactElement {
               });
 
             years.forEach((year: any) => {
-              yearlyMessages.push(
+              yearlyMessages.unshift(
                 channels
                   .map((c) => c.messages)
                   .flat()


### PR DESCRIPTION
Fixes yearly message graph being backwards by adding items to the start of the array instead of the end. There may be a more efficient way to do this whole calculation, which I may look into in the future, so for now this method of using unshift works fine.

Closes #27 