### PR TITLE
prevent emote stretching

### DIFF
--- a/pages/styles/index.css
+++ b/pages/styles/index.css
@@ -570,3 +570,11 @@ input[type="search"]:focus {
 .driver-popover-description {
   color: var(--text-color) !important;
 }
+
+img[alt="emoji"] {
+  object-fit: contain;
+}
+
+.m-2 {
+  margin: 0;
+}


### PR DESCRIPTION
exactly what it says on the tin. emotes that didn't have a 1:1 aspect ratio were stretched to the container's width and height, and I didn't like that. it just adds `object-fit: contain;` to images with "emoji" alt text (`img[alt="emoji"]`) and removes the margins (`margin: 0;`) from the `m-2` class.

this is the most bare-bones implementation possible. I don't know exactly what the expectations are for this sort of thing so feel free to change where it is or how it's implemented.

