### PR TITLE
Fix: Return $0.00 if there are no transactions

### DIFF
--- a/components/utils/index.js
+++ b/components/utils/index.js
@@ -14,7 +14,7 @@ import connectionsJSON from "../json/Connections.json";
 class Utils {
   static getMostUsedCurrency(transactions, amount) {
     if (transactions == null) {
-      return;
+      return '$0.00';
     }
 
     const currenciesUsed = {};


### PR DESCRIPTION
Issue:
- When there aren't any transactions, the text is incomplete as `getMostUsedCurrency()` returns `null` whereas in any other case it returns a string

Before:
![image](https://github.com/peterhanania/Discord-Package/assets/40837031/83faa0d6-5815-4acb-920a-1e18bb93ec43)

After:
![image](https://github.com/peterhanania/Discord-Package/assets/40837031/2d033342-90cb-4304-9ad1-935e6aba6620)

Formatting seen in demo:
![image](https://github.com/peterhanania/Discord-Package/assets/40837031/58a31e8c-6ebb-4d2a-9e5e-ebcce78582a1)

