### PR TITLE
Resolve "Passing props on fragment" error

### DIFF
--- a/components/Data.tsx
+++ b/components/Data.tsx
@@ -10,7 +10,6 @@ import Utils from "./utils";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import {
-  Fragment,
   ReactElement,
   useEffect,
   useState,
@@ -1153,7 +1152,7 @@ export default function Data({ data, demo }: any): ReactElement {
           leave="transition-opacity duration-150"
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
-          as={Fragment}
+          as="div"
         >
           <Dialog
             onClose={() => {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import Tippy from "@tippyjs/react";
-import { useState, Fragment, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Dialog, Transition, Listbox, DialogBackdrop } from "@headlessui/react";
 import Image from "next/image";
 
@@ -40,7 +40,7 @@ export default function Header() {
       leave="transition-opacity duration-150"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
-      as={Fragment}
+      as="div"
     >
       <Dialog
         onClose={() => {
@@ -186,7 +186,7 @@ export default function Header() {
       leave="transition-opacity duration-150"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
-      as={Fragment}
+      as="div"
     >
       <Dialog
         onClose={() => {
@@ -382,7 +382,7 @@ export default function Header() {
       leave="transition-opacity duration-150"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
-      as={Fragment}
+      as="div"
     >
       <Dialog
         onClose={() => {
@@ -544,7 +544,7 @@ export default function Header() {
       leave="transition-opacity duration-150"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
-      as={Fragment}
+      as="div"
     >
       <Dialog
         onClose={() => {
@@ -663,7 +663,7 @@ export default function Header() {
 
                               <Transition
                                 show={open}
-                                as={Fragment}
+                                as="div"
                                 leave="transition ease-in duration-100"
                                 leaveFrom="opacity-100"
                                 leaveTo="opacity-0"

--- a/components/Upload.tsx
+++ b/components/Upload.tsx
@@ -7,7 +7,7 @@ import Tippy from "@tippyjs/react";
 import Utils from "./utils";
 import { Unzip, AsyncUnzipInflate } from "fflate";
 import { Transition, Dialog, DialogBackdrop } from "@headlessui/react";
-import { Fragment, ReactElement } from "react";
+import { ReactElement } from "react";
 import Features from "./json/features.json";
 import EventsJSON from "./json/events.json";
 import { ToastContainer, toast } from "react-toastify";
@@ -2685,7 +2685,7 @@ export default function Upload(): ReactElement<any> {
         leave="transition-opacity duration-150"
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
-        as={Fragment}
+        as="div"
       >
         <Dialog
           onClose={() => {
@@ -3348,6 +3348,7 @@ export default function Upload(): ReactElement<any> {
                                 leave="transition-opacity duration-150"
                                 leaveFrom="opacity-100"
                                 leaveTo="opacity-0"
+                                as="div"
                               >
                                 <div className="animate-fadeIn max-w-screen-lg mx-auto fixed bg-[#2b2d31] inset-x-5 p-5 bottom-10 rounded-lg drop-shadow-2xl flex gap-4 flex-wrap md:flex-nowrap text-center md:text-left items-center justify-center md:justify-between">
                                   <div

--- a/components/privacy.tsx
+++ b/components/privacy.tsx
@@ -2,20 +2,20 @@ import { Transition } from "@headlessui/react";
 import { useState, useEffect, ReactElement } from "react";
 
 export default function Privacy(): ReactElement<any> {
-  const [show, setShow] = useState(true);
-  const [document, setDocument] = useState<any>(null);
+	const [show, setShow] = useState(true);
+	const [document, setDocument] = useState<any>(null);
 
-  useEffect(() => {
-    setDocument(window.document as Document);
-  }, [document]);
+	useEffect(() => {
+		setDocument(window.document as Document);
+	}, [document]);
 
-  function handleRead() {
-    setShow(false);
-    document.cookie = "privacy_read=true; path=/";
-  }
+	function handleRead() {
+		setShow(false);
+		document.cookie = "privacy_read=true; path=/";
+	}
 
-  if (document && document?.cookie.indexOf("privacy_read") === -1) {
-    return (
+	if (document && document?.cookie.indexOf("privacy_read") === -1) {
+		return (
 			<div className="py-6 flex flex-col justify-center sm:py-12 fixed z-50">
 				<section>
 					<Transition
@@ -26,7 +26,8 @@ export default function Privacy(): ReactElement<any> {
 						enterTo="opacity-100"
 						leave="transition-opacity duration-150"
 						leaveFrom="opacity-100"
-						leaveTo="opacity-0">
+						leaveTo="opacity-0"
+						as="div">
 						<div
 							className="fixed inset-0  bg-black/30"
 							onClick={() => {
@@ -93,5 +94,5 @@ export default function Privacy(): ReactElement<any> {
 				</section>
 			</div>
 		);
-  } else return <></>;
+	} else return <></>;
 }

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -1,5 +1,5 @@
 import Tippy from "@tippyjs/react";
-import { useState, Fragment, useEffect, ReactElement } from "react";
+import { useState, useEffect, ReactElement } from "react";
 import { Dialog, Transition, Listbox, DialogBackdrop } from "@headlessui/react";
 import Image from "next/image";
 
@@ -36,7 +36,7 @@ export default function Settings(): ReactElement<any> {
       leave="transition-opacity duration-150"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
-      as={Fragment}
+      as="div"
     >
       <Dialog
         onClose={() => {
@@ -156,7 +156,7 @@ export default function Settings(): ReactElement<any> {
 
                               <Transition
                                 show={open}
-                                as={Fragment}
+                                as="div"
                                 leave="transition ease-in duration-100"
                                 leaveFrom="opacity-100"
                                 leaveTo="opacity-0"


### PR DESCRIPTION
migrate transition as=fragment to as=div

See here for HeadlessUI upgrade information:
https://github.com/tailwindlabs/headlessui/releases/tag/%40headlessui%2Freact%40v2.0.0#user-content-upgrading-from-v1