### PR TITLE
Fixed TypeError in components/utils/index.js:getMostUsedCurrency()

### DIFF
--- a/components/utils/index.js
+++ b/components/utils/index.js
@@ -31,10 +31,11 @@ class Utils {
       .shift();
 
     const currency = currencies?.find(
-      (a) => a?.abbreviation.toLowerCase() === mostUsedCurrency
+      (a) => a?.abbreviation?.toLowerCase() === String(mostUsedCurrency || "").toLowerCase()
     );
 
     // {amount}{symbol}
+    if (!currency) return `$${amount}`;
     if (currency.right) return `${amount}${currency.symbol}`;
     // {symbol}{amount}
     else return `${currency.symbol}${amount}`;


### PR DESCRIPTION
Fixed TypeError in components/utils/index.js:getMostUsedCurrency().
Made currency lookup case-insensitive.
Added null guard: if no match, fall back to $${amount} before accessing currency.right.
